### PR TITLE
TO-13805 Fix auditd service restarts on bootstrap.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'isuftin@usgs.gov'
 license          'CPL-1.0'
 description      'Installs/Configures CIS STIG benchmarks'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.6.29'
+version          '0.6.31'
 source_url       'https://github.com/USGS-CIDA/stig'
 issues_url       'https://github.com/USGS-CIDA/stig/issues'
 

--- a/recipes/auditd.rb
+++ b/recipes/auditd.rb
@@ -17,10 +17,14 @@ service 'auditd' do
   if platform_family?('rhel') && node['init_package'] == 'systemd' && node['platform_version'] < '7.5'
     reload_command '/usr/libexec/initscripts/legacy-actions/auditd/reload'
     restart_command '/usr/libexec/initscripts/legacy-actions/auditd/restart'
+    stop_command '/usr/libexec/initscripts/legacy-actions/auditd/stop'
+    start_command '/usr/libexec/initscripts/legacy-actions/auditd/start'
   end
   if platform_family?('rhel') && node['init_package'] == 'systemd' && node['platform_version'] >= '7.5'
     reload_command '/usr/sbin/service auditd reload'
     restart_command '/usr/sbin/service auditd restart'
+    stop_command '/usr/sbin/service auditd stop'
+    start_command '/usr/sbin/service auditd start'
   end
   supports %i[start stop restart reload status]
   action :enable

--- a/recipes/auditd.rb
+++ b/recipes/auditd.rb
@@ -7,6 +7,26 @@
 #
 # See: https://supermarket.chef.io/cookbooks/auditd
 
+# BEGIN
+# Remove this block wnen this gets resolved: https://github.com/chef-cookbooks/auditd/issues/55
+#
+# Original code cherry-picked from:
+# https://github.com/USGS-CIDA/stig/commit/7f0675a8d853c44302690035cd0aae74d15efdbf#diff-89808a75a87cc415db2e92796115f55a
+
+service 'auditd' do
+  if platform_family?('rhel') && node['init_package'] == 'systemd' && node['platform_version'] < '7.5'
+    reload_command '/usr/libexec/initscripts/legacy-actions/auditd/reload'
+    restart_command '/usr/libexec/initscripts/legacy-actions/auditd/restart'
+  end
+  if platform_family?('rhel') && node['init_package'] == 'systemd' && node['platform_version'] >= '7.5'
+    reload_command '/usr/sbin/service auditd reload'
+    restart_command '/usr/sbin/service auditd restart'
+  end
+  supports %i[start stop restart reload status]
+  action :enable
+end
+# END
+
 auditd_config_dir = '/etc/audit/'
 
 directory auditd_config_dir
@@ -18,10 +38,6 @@ template File.join(auditd_config_dir, 'auditd.conf') do
   group 'root'
   mode 0o640
   notifies :restart, 'service[auditd]', :immediately
-end
-
-service 'auditd' do
-  action :nothing
 end
 
 cookbook_file '/etc/audisp/audispd.conf' do


### PR DESCRIPTION
Expand service resource to include legacy and service functionality. Auditd can only be managed from service, not systemd.